### PR TITLE
Add DPI conversion for extents

### DIFF
--- a/book/src/04_triangle_intro.md
+++ b/book/src/04_triangle_intro.md
@@ -109,7 +109,10 @@ We just have to edit how we define the extent as we create our Swapchain:
 
 ```rust
 let extent = {
-  let window_client_area = window.get_inner_size().ok_or("Window doesn't exist!")?;
+  let window_client_area = window
+    .get_inner_size()
+    .ok_or("Window doesn't exist!")?
+    .to_physical(window.get_hidpi_factor());
   Extent2D {
     width: caps.extents.end.width.min(window_client_area.width as u32),
     height: caps.extents.end.height.min(window_client_area.height as u32),

--- a/examples/camera.rs
+++ b/examples/camera.rs
@@ -575,7 +575,10 @@ impl HalState {
         },
       };
       let extent = {
-        let window_client_area = window.get_inner_size().ok_or("Window doesn't exist!")?;
+        let window_client_area = window
+          .get_inner_size()
+          .ok_or("Window doesn't exist!")?
+          .to_physical(window.get_hidpi_factor());
         Extent2D {
           width: caps.extents.end.width.min(window_client_area.width as u32),
           height: caps

--- a/examples/coordinates.rs
+++ b/examples/coordinates.rs
@@ -573,7 +573,10 @@ impl HalState {
         },
       };
       let extent = {
-        let window_client_area = window.get_inner_size().ok_or("Window doesn't exist!")?;
+        let window_client_area = window
+          .get_inner_size()
+          .ok_or("Window doesn't exist!")?
+          .to_physical(window.get_hidpi_factor());
         Extent2D {
           width: caps.extents.end.width.min(window_client_area.width as u32),
           height: caps

--- a/examples/depth_buffer.rs
+++ b/examples/depth_buffer.rs
@@ -652,7 +652,10 @@ impl HalState {
         },
       };
       let extent = {
-        let window_client_area = window.get_inner_size().ok_or("Window doesn't exist!")?;
+        let window_client_area = window
+          .get_inner_size()
+          .ok_or("Window doesn't exist!")?
+          .to_physical(window.get_hidpi_factor());
         Extent2D {
           width: caps.extents.end.width.min(window_client_area.width as u32),
           height: caps

--- a/examples/instanced_drawing.rs
+++ b/examples/instanced_drawing.rs
@@ -665,7 +665,10 @@ impl HalState {
         },
       };
       let extent = {
-        let window_client_area = window.get_inner_size().ok_or("Window doesn't exist!")?;
+        let window_client_area = window
+          .get_inner_size()
+          .ok_or("Window doesn't exist!")?
+          .to_physical(window.get_hidpi_factor());
         Extent2D {
           width: caps.extents.end.width.min(window_client_area.width as u32),
           height: caps

--- a/examples/shaders.rs
+++ b/examples/shaders.rs
@@ -201,7 +201,10 @@ impl HalState {
         },
       };
       let extent = {
-        let window_client_area = window.get_inner_size().ok_or("Window doesn't exist!")?;
+        let window_client_area = window
+          .get_inner_size()
+          .ok_or("Window doesn't exist!")?
+          .to_physical(window.get_hidpi_factor());
         Extent2D {
           width: caps.extents.end.width.min(window_client_area.width as u32),
           height: caps

--- a/examples/textures.rs
+++ b/examples/textures.rs
@@ -480,7 +480,10 @@ impl HalState {
         },
       };
       let extent = {
-        let window_client_area = window.get_inner_size().ok_or("Window doesn't exist!")?;
+        let window_client_area = window
+          .get_inner_size()
+          .ok_or("Window doesn't exist!")?
+          .to_physical(window.get_hidpi_factor());
         Extent2D {
           width: caps.extents.end.width.min(window_client_area.width as u32),
           height: caps

--- a/examples/triangle_intro.rs
+++ b/examples/triangle_intro.rs
@@ -181,7 +181,10 @@ impl HalState {
         },
       };
       let extent = {
-        let window_client_area = window.get_inner_size().ok_or("Window doesn't exist!")?;
+        let window_client_area = window
+          .get_inner_size()
+          .ok_or("Window doesn't exist!")?
+          .to_physical(window.get_hidpi_factor());
         Extent2D {
           width: caps.extents.end.width.min(window_client_area.width as u32),
           height: caps


### PR DESCRIPTION
Converting the inner_size from LogicalSize to PhysicalSize ensures the framebuffer matches the window on displays with DPI other than 1, such as mine.
Only the extents require this conversion, leaving `mouse_{x,y}` and `frame_{width,height}` in LogicalSize

Related Documentation:
https://docs.rs/winit/*/winit/struct.Window.html#method.get_inner_size