### PR TITLE
Include link to shaderc-rs setup info

### DIFF
--- a/book/src/04_triangle_intro.md
+++ b/book/src/04_triangle_intro.md
@@ -423,7 +423,8 @@ the GPU. We take a few shader modules and put them together into a
 
 For this to work, you have to use the `shaderc-rs` crate, which takes _very_
 long to build that first time because it's actually using `build.rs` to download
-a relatively massive C++ lib and then link that in.
+a relatively massive C++ lib and then link that in. Be sure to see the `shaderc-rs`
+[setup instructions](https://github.com/google/shaderc-rs#setup).
 
 1) We open a compiler
 2) We compile some Vertex Shader source. This is "where do the points go on the


### PR DESCRIPTION
I had a bit of trouble finding out why the triangle-intro wouldn't build. I do see that the setup for shaderc-rs is mentioned in the root readme now, but there is no mention of it in the tutorial text.  This just adds a quick mention and link to the tutorial text.