### PR TITLE
Manually drop `queue_group` too

### DIFF
--- a/book/src/03_clear_the_window.md
+++ b/book/src/03_clear_the_window.md
@@ -1638,9 +1638,10 @@ self
   .destroy_swapchain(ManuallyDrop::into_inner(read(&mut self.swapchain)));
 ```
 
-And for our two final items we just use the `ManuallyDrop::drop` style:
+And for our three final items we just use the `ManuallyDrop::drop` style:
 
 ```rust
+ManuallyDrop::drop(&mut self.queue_group);
 ManuallyDrop::drop(&mut self.device);
 ManuallyDrop::drop(&mut self._instance);
 ```
@@ -1663,7 +1664,7 @@ pub struct HalState {
   image_views: Vec<(<back::Backend as Backend>::ImageView)>,
   render_pass: ManuallyDrop<<back::Backend as Backend>::RenderPass>,
   render_area: Rect,
-  queue_group: QueueGroup<back::Backend, Graphics>,
+  queue_group: ManuallyDrop<QueueGroup<back::Backend, Graphics>>,
   swapchain: ManuallyDrop<<back::Backend as Backend>::Swapchain>,
   device: ManuallyDrop<back::Device>,
   _adapter: Adapter<back::Backend>,


### PR DESCRIPTION
Fixes this error in my environment (Linux 5.0.4-arch1-1-ARCH, NVIDIA GTX 980,  Driver 418.56) using the Vulkan backend:

```
UNASSIGNED-ObjectTracker-ObjectLeak(ERROR / SPEC): msgNum: 0 - OBJ ERROR : VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT object 0x5587ae31a460 has not been destroyed.
    Objects: 1
        [0] 0x5587ae31a460, type: 3, name: NULL
```